### PR TITLE
add eol notice

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+	"skip-icons-check": true,
+	"end-of-life": "This application longer has a maintainer and the codebase has been archived."
+}


### PR DESCRIPTION
see https://github.com/qTox/qTox#this-repository-and-qtox-are-unmaintained

> Due to a lack of resources, qTox is no longer maintained.
>
> If someone with provable C++ experience and sufficient resources to maintain qTox wants to take over I'm happy to discuss that. Meanwhile be careful about "official forks" of qTox unless you read it here, they are probably not official.