### PR TITLE
Update runtime to 6.10

### DIFF
--- a/io.github.qtox.qTox.json
+++ b/io.github.qtox.qTox.json
@@ -57,6 +57,10 @@
                 "cflags": "-DSQLITE_HAS_CODEC",
                 "ldflags": "-lcrypto"
             },
+            /* Fix eu-strip failed with Permission denied */
+            "post-install": [
+                "chmod -Rf u+w ${FLATPAK_DEST}/lib"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
- Update runtime to 6.10
- Drop the FFMPEG extension, which is already provided by the runtime
- Update SQLCipher version to 4.4.3 to fix build error
- Update c-toxcore version
- Update qTox version
- Use  "cxxflags": "-Wno-error=unused-result -Wno-error=deprecated-declarations" to suppress some QT related errors

Fixes: https://github.com/flathub/io.github.qtox.qTox/issues/46
